### PR TITLE
Read from S3 and other tweaks

### DIFF
--- a/raster2points/raster2csv.py
+++ b/raster2points/raster2csv.py
@@ -23,10 +23,12 @@ def str2bool(v):
 
 
 def main():
-
-    logger = logging.getLogger()
-    logger.setLevel(logging.INFO)
+    logger = logging.getLogger('raster2points')
     handler = logging.StreamHandler(sys.stdout)
+    handler.setFormatter(
+        logging.Formatter(fmt='%(asctime)s %(levelname)-4s %(message)s',
+                          datefmt='%Y-%m-%d %H:%M:%S')
+    )
     logger.addHandler(handler)
 
     parser = argparse.ArgumentParser(description="Convert raster to CSV")
@@ -78,6 +80,13 @@ def main():
         help="Number of workers to run in parallel",
     )
 
+    parser.add_argument(
+        "--verbose",
+        "-v",
+        action='store_true',
+        help="Print additional logging",
+    )
+
     args = parser.parse_args()
 
     if args.separator == "t":
@@ -85,8 +94,12 @@ def main():
     else:
         separator = args.separator
 
-    files = args.input + [args.output]
+    if args.verbose:
+        logger.setLevel(logging.DEBUG)
+    else:
+        logger.setLevel(logging.INFO)
 
+    files = args.input + [args.output]
     start = datetime.now()
     try:
         raster2csv(
@@ -98,9 +111,9 @@ def main():
             workers=args.workers
         )
     except (AssertionError, RasterioIOError) as e:
-        logging.error(e, exc_info=logger.getEffectiveLevel() == logging.DEBUG)
+        logger.error(e, exc_info=logger.getEffectiveLevel() == logging.DEBUG)
         sys.exit(1)
-    logging.info("time elapsed: {}".format(datetime.now() - start))
+    logger.info("time elapsed: {}".format(datetime.now() - start))
 
 
 if __name__ == "__main__":

--- a/raster2points/raster2csv.py
+++ b/raster2points/raster2csv.py
@@ -1,9 +1,11 @@
 import argparse
-from raster2points import raster2csv
-from rasterio.errors import RasterioIOError
+from datetime import datetime
 import logging
 import sys
-from datetime import datetime
+
+from rasterio.errors import RasterioIOError
+
+from raster2points import raster2csv
 
 
 def str2bool(v):

--- a/raster2points/raster2points.py
+++ b/raster2points/raster2points.py
@@ -9,6 +9,8 @@ from parallelpipe import Stage
 import rasterio
 from rasterio.windows import Window
 
+logger = logging.getLogger('raster2points')
+
 
 def raster2csv(
     *files,
@@ -34,7 +36,7 @@ def raster2csv(
     csv_file = files[-1:][0]  # files[-1:] returns a tuple with one element
     src_rasters = files[:-1]
 
-    logging.info(
+    logger.info(
         "Extract data using {} worker{}".format(workers, "" if workers == 1 else "s")
     )
     table = raster2df(
@@ -44,10 +46,10 @@ def raster2csv(
         calc_area=calc_area
     )
 
-    logging.info("Write to file: " + csv_file)
+    logger.info("Write to file: " + csv_file)
     table.to_csv(csv_file, sep=separator, header=True, index=False)
 
-    logging.info("Done.")
+    logger.info("Done.")
 
 
 def raster2df(
@@ -103,6 +105,7 @@ def raster2df(
         else:
             data_frame = pd.concat([data_frame, df[0]])
 
+    logger.debug("Renaming columns")
     if col_names:
         i = 0
         for col_name in col_names:
@@ -177,9 +180,10 @@ def _process_blocks(
     """
 
     for block in blocks:
-
         col = block[0]
         row = block[1]
+
+        logger.debug("Processing block ({}, {})".format(col, row))
 
         w_width = _get_window_size(col, step_width, width)
         w_height = _get_window_size(row, step_height, height)

--- a/raster2points/raster2points.py
+++ b/raster2points/raster2points.py
@@ -1,12 +1,13 @@
-from rasterio.windows import Window
-from parallelpipe import Stage
-import rasterio
-import numpy as np
-import pandas as pd
 import math
 import itertools
-from numba import jit
 import logging
+
+from numba import njit
+import numpy as np
+import pandas as pd
+from parallelpipe import Stage
+import rasterio
+from rasterio.windows import Window
 
 
 def raster2csv(

--- a/raster2points/raster2points.py
+++ b/raster2points/raster2points.py
@@ -270,27 +270,27 @@ def _get_values(sources, window, threshold=0):
     return df
 
 
-@jit()  # using numba.jit to precompile calculations
+@njit()  # using numba.jit to precompile calculations
 def _get_mask(w, threshold):
     return w > threshold
 
 
-@jit()  # using numba.jit to precompile calculations
+@njit()  # using numba.jit to precompile calculations
 def _apply_mask(mask, w):
     return np.extract(mask, w)
 
 
-@jit()  # using numba.jit to precompile calculations
+@njit()  # using numba.jit to precompile calculations
 def _get_index(array):
     return np.nonzero(array)
 
 
-@jit()  # using numba.jit to precompile calculations
+@njit()  # using numba.jit to precompile calculations
 def _get_coord(index, size, offset):
     return index * size + offset + (size / 2)
 
 
-@jit()  # using numba.jit to precompile calculations
+@njit()  # using numba.jit to precompile calculations
 def _get_area(lat, d_lat, d_lon):
     """
     Calculate geodesic area for grid cells using WGS 1984 as spatial reference.
@@ -310,7 +310,7 @@ def _get_area(lat, d_lat, d_lon):
     e = math.sqrt(1 - (b / a) ** 2)
 
     area = (
-        abs(
+        np.abs(
             (
                 pi
                 * b ** 2

--- a/raster2points/raster2points.py
+++ b/raster2points/raster2points.py
@@ -42,7 +42,8 @@ def raster2csv(
         *src_rasters,
         col_names=col_names,
         max_block_size=max_block_size,
-        calc_area=calc_area
+        calc_area=calc_area,
+        workers=workers,
     )
 
     logger.info("Write to file: " + csv_file)

--- a/raster2points/raster2points.py
+++ b/raster2points/raster2points.py
@@ -30,10 +30,9 @@ def raster2csv(
     :param max_block_size: max block size to process
     :return: None
     """
-
     assert len(files) >= 2, "No output file provided"
 
-    csv_file = files[-1:][0]  # files[-1:] returns a tuple with one element
+    csv_file = files[-1]
     src_rasters = files[:-1]
 
     logger.info(

--- a/readme.md
+++ b/readme.md
@@ -11,6 +11,8 @@ Input files can be local file paths or S3 paths, or a mix. For reading from
 S3, you'll need [AWS credentials configured](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html),
 such as with a profile in `~/.aws` and an `AWS_PROFILE` variable in your environment.
 
+Multi-worker only works with S3 inputs, not local files.
+
 ## Installation and Dependencies
 
 This module uses rasterio and requires `GDAL>=1.11`.

--- a/readme.md
+++ b/readme.md
@@ -7,6 +7,9 @@ Successive input rasters will use data mask from first input raster.
 
 Returns a Pandas dataframe, CLI will export results as CSV file.
 
+Input files can be local file paths or S3 paths, or a mix. For reading from
+S3, you'll need [AWS credentials configured](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html),
+such as with a profile in `~/.aws` and an `AWS_PROFILE` variable in your environment.
 
 ## Installation and Dependencies
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-rasterio
-pandas
-pre-commit
 numba
+pandas
 parallelpipe
+pre-commit
 pytest
+rasterio

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ pandas
 parallelpipe
 pre-commit
 pytest
-rasterio
+rasterio[s3]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-numba
-pandas
-parallelpipe
-pre-commit
-pytest
-rasterio[s3]
+numba ~=0.44.1
+pandas ~=0.24.2
+parallelpipe ~=0.2.6
+pre-commit ~=1.17.0
+pytest ~=4.6.3
+rasterio[s3] ~=1.0.24


### PR DESCRIPTION
This is a grab bag of small changes made while processing a set of tiles. It...
- Adds the ability to read input files directly from S3 (which turned out to be extremely easy, since it's a feature that's implemented in Rasterio and just works once the package is installed with that option enabled)
- Adds a few debug-level logging statements and a `--verbose` option to set the log level to DEBUG
- Sends the `--workers` argument through to the `raster2df` function where it will have an effect.  It was getting dropped one step early, so the actual data processing was always running with only 1 worker.
  - Note: it turns out Rasterio runs into read errors and crashes if you have multiple threads processing the same local file, because it tries to share a single file cursor.  So the rehabilitated `--workers` option should only be used with S3 inputs.
- Resolves the issue `numba` was having running precompilation on `_get_area`, which was producing a warning.
- Reorders imports into sections (standard library, packages, this package), and alphabetical within sections.
- Adds version specifiers to `requirements.txt`

It should work the same as before, except that `--workers` will now have an effect (and if the input files are local that effect will be crashing).  Here's an example command that uses multiple workers and the new `--verbose` option:
```
raster2csv.py --col_names year --calc_area true --workers 4 --verbose 's3://gfw2-data/forest_change/hansen_2018/40N_120W.tif' 40N_120W.csv
```